### PR TITLE
Updating to 0.6.2 and including latest SHA SUMS for v1.4.1 through to v1.4.5 as setting default version to v1.4.5

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,10 +1,26 @@
 node.default['packer']['url_base'] = 'https://releases.hashicorp.com/packer'
-node.default['packer']['version'] = '1.0.4'
+node.default['packer']['version'] = '1.4.5'
 node.default['packer'][node.default['packer']['version']]['prefix'] = ''
 node.default['packer']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "386"
 
 # Transform raw output of the bintray checksum list into a Hash[filename, checksum].
 # https://dl.bintray.com/mitchellh/packer/${VERSION}_SHA256SUMS?direct
+
+node.default['packer']['0.5.1']['raw_checksums'] = <<-EOF
+    a0d8db4944d0024af05e256357cad014662eddefef67b1b2fe8a5060659a5be2  0.5.1_darwin_386.zip
+    56bec31f0d3540d566ef86979b25367660d7e72c010c9d87ef91c5c2138e9eae  0.5.1_darwin_amd64.zip
+    337651f4dd4f897413eb07e8d2cd821a0246d04c4235ce398af58f7939e097e1  0.5.1_freebsd_386.zip
+    ae356b68517aa75d08736c44d838b6bd4a19203315ee8afffff5de35684e1464  0.5.1_freebsd_amd64.zip
+    bbd2468d69195b4227034aa07474e87c2bcfe2250ae620085219e870e6b33bf6  0.5.1_freebsd_arm.zip
+    cc7741165a3d5f66c1d4af3ea3b1e80ebe03cb2ce5e0ff27ff43ecac64f1dc7a  0.5.1_linux_386.zip
+    fa68149f4356ad48a6393dbf9e81839a40aad115e5bad83833ff9ccf6a0239b8  0.5.1_linux_amd64.zip
+    6a6b724df3bc51478cc1cd4ccbc000924bbe9018a4ded74d3b6e0409cb9092e0  0.5.1_linux_arm.zip
+    a2ff5410a871baafef2ffd1924f5b6d7fe1ba443ba0b23071e2c928935d173e6  0.5.1_openbsd_386.zip
+    41c1edd5faf9041081f1dbaa6eb14e9f18cdb25a8dab85f33c08701bd0275817  0.5.1_openbsd_amd64.zip
+    350480400d31c00e1604fce8744b5f3d279c15cf8c49cd7b59e1412e316dae01  0.5.1_windows_386.zip
+    6c5c43aa92f41f23199b9142f08950e57e400e3fed9196132a111f65b499c214  0.5.1_windows_amd64.zip
+EOF
+
 node.default['packer']['0.5.1']['raw_checksums'] = <<-EOF
     a0d8db4944d0024af05e256357cad014662eddefef67b1b2fe8a5060659a5be2  0.5.1_darwin_386.zip
     56bec31f0d3540d566ef86979b25367660d7e72c010c9d87ef91c5c2138e9eae  0.5.1_darwin_amd64.zip
@@ -134,6 +150,123 @@ node.default['packer']['1.0.4']['raw_checksums'] = <<-EOF
     8e05658de4ba4170530b5e73f6f241a8652a685517797c4323ea6e0b65a4f37c  packer_0.12.0_windows_386.zip
     1a2ae283a71810a307299c05df73e96890fb7503f1b32c52850356ddb750d877  packer_0.12.0_windows_amd64.zip
 EOF
+
+node.default['packer']['1.4.1']['prefix'] = "packer_"
+node.default['packer']['1.4.1']['raw_checksums'] = <<-EOF
+    0dea781045103178ffd8a469c5e0b0f7b91561d0643d849969e37e8801d304a9  packer_1.4.1_darwin_386.zip
+    2c5d4a2d0bf9e02dc790fddaa0a74e8fedb6ddd74c6f3b85d04536d9d757fe07  packer_1.4.1_darwin_amd64.zip
+    ce8f1ccde4e132b74217bf4dd98a828254196d244eadd892b76bb745f52c36b8  packer_1.4.1_freebsd_386.zip
+    419632e9af87e26efc6d5ff8d30fe442c106bb0210e9c585e9e05bf40ea7aef2  packer_1.4.1_freebsd_amd64.zip
+    1f74851a732b550dee445e53af1d31e175c0008d000609188fbc05542ea7c817  packer_1.4.1_freebsd_arm.zip
+    20ca7ed8120a37867cbd8b9293f0b28649445f607d0754fddee47595d811ca62  packer_1.4.1_linux_386.zip
+    b713ea79a6fb131e27d65ec3f2227f36932540e71820288c3c5ad770b565ecd7  packer_1.4.1_linux_amd64.zip
+    2a57bf77fc7b9f52195ac4b84fd5fc890e7356dbc97154507d54de2d7030fa1b  packer_1.4.1_linux_arm.zip
+    b8d2f264f0e4760346a9848f73fcbfba2907db97778d9dbb2f70d20411518b74  packer_1.4.1_linux_arm64.zip
+    743c6cf9169914730692d6fc8cdb7ecbf400a63213f327753853e888ad44e5df  packer_1.4.1_linux_mips.zip
+    ecd290c7a7d8b28d816066241a7c929bafd88468869d17950d2802c4ac52a30a  packer_1.4.1_linux_mips64.zip
+    4dbd7362f10580ef06a5a98762ae3781043319b888de2b527101977dce29b673  packer_1.4.1_linux_mipsle.zip
+    889c2a4637f92f14858b395c62c73eaac0dbd88d92ff898472739cb7493f0f77  packer_1.4.1_linux_ppc64le.zip
+    bccf4fba24fddfd9d9a062e1ac4b360d2e86a7f3269cac0136a34646bae14fdb  packer_1.4.1_linux_s390x.zip
+    f2d47e5e13b899ac41e4c1639fc68efa877f748cce3f9cffc06b74d09552d8c6  packer_1.4.1_openbsd_386.zip
+    74792d0ec9897e0b8740e4cf03e767aeee5e6b8e3233c9463bd663a921c26017  packer_1.4.1_openbsd_amd64.zip
+    5aded26308d05b3b3b256ba160dd190cee73aa4cd8461c12af5990d5a137f27f  packer_1.4.1_solaris_amd64.zip
+    943a3fd48b86cbc9e0014358d0cf662aa6827315ac61c613de62eb4cd59ae6e7  packer_1.4.1_windows_386.zip
+    78416314aecbc166486fd8a7784523436c5c8673a1788047b14140f43977d72c  packer_1.4.1_windows_amd64.zip
+
+EOF
+
+node.default['packer']['1.4.2']['prefix'] = "packer_"
+node.default['packer']['1.4.2']['raw_checksums'] = <<-EOF
+    7f7e134c268e68de3f426deb17fdb2baa8d75bfd0a055fa754cde35195d4dec7  packer_1.4.2_darwin_386.zip
+    4e9bf72be16b00953dd7213e19fba97de569b91d8b8116b190efd647efe7d047  packer_1.4.2_darwin_amd64.zip
+    0977e5237a2c64575860142c23daadfd906b78f887a979d2a881550f7cff2f56  packer_1.4.2_freebsd_386.zip
+    63617c9de21f2b393edfbb875c82702335cb53449e68ad4171826b68054c967c  packer_1.4.2_freebsd_amd64.zip
+    cc1ce3869872c8022751985c3d91c1f7780224de87404fe0cc1c76dab2c5d99c  packer_1.4.2_freebsd_arm.zip
+    30e26eb19cef96bc759df42e4fb2a15399b45a121af900c589e110953a607197  packer_1.4.2_linux_386.zip
+    2fcbd1662ac76dc4dec381bdc7b5e6316d5b9d48e0774a32fe6ef9ec19f47213  packer_1.4.2_linux_amd64.zip
+    b883a6f0da25ce9aef2ed722bf32cf94fcdaf35f8652093b866c9b40efc38fbe  packer_1.4.2_linux_arm.zip
+    58d6b853186f9cd8d55f07b88f65d01e12926cc4c46d270bef2f5c1da3da5cd7  packer_1.4.2_linux_arm64.zip
+    55f919f27471960da70dc0f83f419cf490ea7704dc521652cf4e1947cc1d2dd0  packer_1.4.2_linux_mips.zip
+    7f49b0178f997e5b0f41f133db8ab3fd05ab425f48bedbed26b726db35fe75eb  packer_1.4.2_linux_mips64.zip
+    e2c1e16879dc03b602d067761d48a4de5378499495481f66ca4d93d7a7805a38  packer_1.4.2_linux_mipsle.zip
+    01e66485ace04c4404017a8646f785440418b0ec935a4873bfef39b8aefc7074  packer_1.4.2_linux_ppc64le.zip
+    02000defc62f0c4eeee1d11dfe6f5f4eea47f96dd7ba6d25ae72fd9038b06836  packer_1.4.2_linux_s390x.zip
+    d1975d4fddd2eebfbeedf57af47cb3a97464c8b204988d11194b86c84ea65a52  packer_1.4.2_openbsd_386.zip
+    6ffbe317443cc335be56df6ee87f58d4616cebacc8795542d6ce0b0b66c7a6f3  packer_1.4.2_openbsd_amd64.zip
+    0aa5b593f9021a81aae8b53f90c346d68fc40e6fdf6e50ce702b2a67a2a80bbd  packer_1.4.2_solaris_amd64.zip
+    dfd8c17a1ad6a1c5cbeb9f9bee220fd45ff3c877186ec1e571f5a3ed646f5284  packer_1.4.2_windows_386.zip
+    0db7527e81672d51fc436081eff0e49e8873baee0564e427c5dc73a3f44fa840  packer_1.4.2_windows_amd64.zip
+EOF
+
+node.default['packer']['1.4.3']['prefix'] = "packer_"
+node.default['packer']['1.4.3']['raw_checksums'] = <<-EOF
+    d892c163c6fc1c10b7784a04664a9235e06df830f760d98f84910842a4192875  packer_1.4.3_darwin_386.zip
+    9b479c5442f81991eda777445fd07cc4582c573989863c2df56268b2db791bbc  packer_1.4.3_darwin_amd64.zip
+    5f6c4abc924a67b985fea04175c9b44a9b64b6e474de9630357d4bf06e9e597b  packer_1.4.3_freebsd_386.zip
+    773619f22b3205137aa9d5bda109637ec1aab379e1cf9933320da79cf985d0d2  packer_1.4.3_freebsd_amd64.zip
+    eb79bba27ea71b5c64acf94cfbbe5a2e34f35f16c091c4f1c86937c309f55d47  packer_1.4.3_freebsd_arm.zip
+    53ea97ec6f7f92520e2b4a9a2fcb3a4a8b8239711b24bccc489c1528a7acc561  packer_1.4.3_linux_386.zip
+    c89367c7ccb50ca3fa10129bbbe89273fba0fa6a75b44e07692a32f92b1cbf55  packer_1.4.3_linux_amd64.zip
+    cd792228fb45d16ec0748208aa91802c3559649cf678aebde2f1f98de71f42a2  packer_1.4.3_linux_arm.zip
+    672c9c7c6e56bd0c4d9c1df870c2d985522492624024be1b175b8f4697ad1d38  packer_1.4.3_linux_arm64.zip
+    c04279b110be823fb1c5f284c7b894a6c19699d2367bf3ffcb128aa7eb9aea66  packer_1.4.3_linux_mips.zip
+    5fd113f504bc4af31160552365c043c3c207a91e7a773f0f3c5431841a96cb5e  packer_1.4.3_linux_mips64.zip
+    44a48994b19be56afd1cbea3a443038c428e53ebd7e6f7cdbd0331a0c926e83c  packer_1.4.3_linux_mipsle.zip
+    e2c9674fcfa702c95785b77d665cf505093288de8bcf5e72ac8b204edf88e9ba  packer_1.4.3_linux_ppc64le.zip
+    029156a00bc70473157fdd5189223e7d802f18e86acf1a34475a2546bced08d9  packer_1.4.3_linux_s390x.zip
+    8394328174eb166250261763b872ad29f839fa650cf90177cbd89f2200401678  packer_1.4.3_openbsd_386.zip
+    6cffbd51003f7f3670331242e95df413d496d40fb82f86168230a718128130e3  packer_1.4.3_openbsd_amd64.zip
+    bdd1bd14f4d03d7303cf35992b44488e57b95add2c71d3ee41ccb9b817dd3ce2  packer_1.4.3_solaris_amd64.zip
+    46d1fbb4a6e8afe65164fcbaaa08ac21bddc4a0b2f8f9ce25d6586172c0bbb41  packer_1.4.3_windows_386.zip
+    9df329285c46bb3e64462c7a6f2f0673b227466564ff1b6739d930d3aee719fe  packer_1.4.3_windows_amd64.zip
+EOF
+
+
+node.default['packer']['1.4.4']['prefix'] = "packer_"
+node.default['packer']['1.4.4']['raw_checksums'] = <<-EOF
+    584378edfb361f45763c257e480a4b68b38ef4cf9a2154c163d4195539b010f8  packer_1.4.4_darwin_386.zip
+    d57c8ecc3b4356b176e600e4de420fc3feba1ca0d95693dfabb0860145b720b1  packer_1.4.4_darwin_amd64.zip
+    095d72add4692e3aba9bd61f8fce17bd8343560ddbd05fd5273f7b4b392979d8  packer_1.4.4_freebsd_386.zip
+    e47841c124a6e71f0711f0bb9e020f3279470ad33933a58545d7a68e2a36aa61  packer_1.4.4_freebsd_amd64.zip
+    a1a3773305453c81c48a5f5c0d2df91d64a44c29063e3d5dccd6be77fef3bcea  packer_1.4.4_linux_386.zip
+    b4dc37877a0fd00fc72ebda98977c2133be9ba6b26bcdd13b1b14a369e508948  packer_1.4.4_linux_amd64.zip
+    0cac826f983172aa836da65f76aa535fe7eacdece0510832ccfe3b51cb8dfe47  packer_1.4.4_linux_arm.zip
+    c6930cf5afdeb99df3ed5c9eeeef89fbcb3a1a71a9e17ebba16c873405ab72cd  packer_1.4.4_linux_arm64.zip
+    f8fb352c9a036617f2250c9bdb60ac29cecaafcd64da4c65b4805883e26f8f2b  packer_1.4.4_linux_mips.zip
+    1c946178edd341bb4765dee76e60164c33d0251ef80331e8a754da6965b78cc9  packer_1.4.4_linux_mips64.zip
+    83956733c86717acf0ccb65cf64ea8b338e0c13395314a7615339047125eae13  packer_1.4.4_linux_mipsle.zip
+    88810d5f07db78e87c062325abf6ef332cc7025d02dcbac54eaecff31962be4c  packer_1.4.4_linux_ppc64le.zip
+    a8ce4d557763431ff56cf3c0d40aa753fe1408492a612b2dff0295c629943bce  packer_1.4.4_linux_s390x.zip
+    f69c02cfec16aefa0c4e6d35eda84aaf3b2873658383f565a2e8785856217d84  packer_1.4.4_openbsd_386.zip
+    7f21fb2ee4e8adfeaf96c53df02aa09f223cf2ebeadaf63bd2402de904e465bd  packer_1.4.4_openbsd_amd64.zip
+    6b7a7ddb7deab30d7ae804bb3ef0aed1a0133d315f0802331593d849a80ae4cf  packer_1.4.4_solaris_amd64.zip
+    2cb20b287c3063d45fb820a3973992ff5ae6269a90caf39945b133b64966f16a  packer_1.4.4_windows_386.zip
+    310a98e6ac7d4ee4f306a5f8385628a2e79a2cb8f7d2e894379e3a97ff5ed35b  packer_1.4.4_windows_amd64.zip
+EOF
+
+node.default['packer']['1.4.5']['prefix'] = "packer_"
+node.default['packer']['1.4.5']['raw_checksums'] = <<-EOF
+    91ac2b952fb1c7b13d8b42686823cad4d39ec319ca23f603c27fd8e45fc3c5f8  packer_1.4.5_darwin_386.zip
+    97328422361ad69553522786100a62a774eb2cebe0cd89cfb531b53efbf8c9f9  packer_1.4.5_darwin_amd64.zip
+    0af8e0072985060d741aa30597dd0ebf99b308e614247fdeae17b00043e6ed5c  packer_1.4.5_freebsd_386.zip
+    ffbb40d73f270197c63e733d49d5e641df7e0fa8defe152f765fdc6d957c34ef  packer_1.4.5_freebsd_amd64.zip
+    8d0f70e9304ecdfd28f73154611e9cf6ecdca208cafce9ca23644b71a3c3d845  packer_1.4.5_linux_386.zip
+    30da8dab9c526a6d15b037e2234f6f12cf3accfad77eb2c130738ec1a54cab6d  packer_1.4.5_linux_amd64.zip
+    2d3698966c8dacb10d049e887f14efdb7d2bae4ebbac83f22c17483e70d67a48  packer_1.4.5_linux_arm.zip
+    8a0c4fa7ba6545c9a27cb8d47bca6ce5fbcbabc72b37c4670d2a58e2bded3792  packer_1.4.5_linux_arm64.zip
+    ac265918809907e142752a1c75ec329ce9a05cba163d7c52ed11fe1f5c8b180c  packer_1.4.5_linux_mips.zip
+    80bb4b671e69c7b821c7fa1106c271c44106d4a3f955963d6cf2607699db80e5  packer_1.4.5_linux_mips64.zip
+    e30138ad656308f3bbe4a702c7efbc4167790e9df2c146ad286c68f18d51f089  packer_1.4.5_linux_mipsle.zip
+    0bb1725728a65f42eb7aec390534c864bb9ca93097729500108384b81eae2c8e  packer_1.4.5_linux_ppc64le.zip
+    5681b164400eb6996df9ab3c984e871f63d2b5e1573c07fe63fc575fbcb4ecf1  packer_1.4.5_linux_s390x.zip
+    27059486f6e2b3d2f4fa09d0ccab032338810addcf243dc8d4cc860e520a2630  packer_1.4.5_openbsd_386.zip
+    8fe6851fa7611f01ada66857405c98a902edf0c7b2a48656125ead316af0ce28  packer_1.4.5_openbsd_amd64.zip
+    426592efbb378afacc07bc5905362f8094372fb99102aead4f5fe70d0aaf1afb  packer_1.4.5_solaris_amd64.zip
+    1036a77f5775a88e24c74340dc40f5f47a50165edc2675b5de3758b0775cb6cb  packer_1.4.5_windows_386.zip
+    5da1b38beaad735a8b7390865d33e5f60d830fa93e5485f593aae2254dcc4ad8  packer_1.4.5_windows_amd64.zip
+EOF
+
+
 
 node.default['packer']['checksums'] = Hash[
     node['packer'][node['packer']['version']]['raw_checksums'].split("\n").collect { |s| s.split.reverse }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'alex@strataconsutling.com'
 license          'Apache 2.0'
 description      'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.1'
+version          '0.6.2'
 
 depends 'ark', '~> 3.1.0'
 depends 'apt'


### PR DESCRIPTION
Updating to 0.6.2 and including latest SHA SUMS for v1.4.1 through to v1.4.5 as setting default version to v1.4.5